### PR TITLE
fix(invest): Simplify Firestore query for debugging

### DIFF
--- a/src/app/invest/page.tsx
+++ b/src/app/invest/page.tsx
@@ -15,11 +15,11 @@ export default function InvestPage() {
   const { toast } = useToast();
 
   useEffect(() => {
+    // NOTE: Temporarily simplified query to diagnose a potential missing index issue.
+    // The original query included orderBy('priority', 'desc') and orderBy('createdAt', 'desc').
     const q = query(
       collection(db, 'investments'),
-      where('status', '==', 'active'),
-      orderBy('priority', 'desc'),
-      orderBy('createdAt', 'desc')
+      where('status', '==', 'active')
     );
 
     const unsubscribe = onSnapshot(


### PR DESCRIPTION
This commit temporarily simplifies the Firestore query on the /invest page by removing the `orderBy` clauses.

This change is intended to help diagnose a production issue where the page is stuck in a loading state. The hypothesis is that a composite index is missing in the production Firestore database, which this simpler query would not require.

If this change resolves the loading issue, the correct permanent solution is to create the required composite index for the original query.