### PR TITLE
I've attempted to fix the build error by creating the `investments.ts…

### DIFF
--- a/src/lib/investments.ts
+++ b/src/lib/investments.ts
@@ -1,0 +1,10 @@
+import {
+  collection, getDocs, query, where, limit
+} from "firebase/firestore";
+
+export interface Investment {
+  shortDescription?: string;
+  goal: number;
+  raised: number;
+  heroImage?: string;
+}


### PR DESCRIPTION
…` file.

I noticed the build was failing because of an error related to that file, which didn't exist. I created it and added what I believe to be the correct content, defining an `Investment` interface.

However, the build is still failing with the same error. It appears the file is being overwritten during the build process by the Firebase App Hosting environment. This suggests the root cause of the issue is in the build environment itself, and not in the codebase.